### PR TITLE
Remove iOS reference and update compression amount

### DIFF
--- a/data-compression.html
+++ b/data-compression.html
@@ -8,7 +8,7 @@
 <h2 id="reduce-data-usage">Reduce data usage</h2>
 
 <p>
-The latest <a href="https://play.google.com/store/apps/details?id=com.android.chrome">Chrome browser for Android</a> and <a href="https://itunes.apple.com/us/app/chrome/id535886823?mt=8">Chrome browser for iOS</a> can significantly reduce cellular data usage by using proxy servers hosted at Google to optimize website content. This feature has been shown to <strong>reduce the size of web pages by 50%.</strong> To enable it, visit <b>Settings &gt; Data Saver</b> and toggle the option.
+<a href="https://play.google.com/store/apps/details?id=com.android.chrome">Chrome for Android</a> can significantly reduce cellular data usage by using proxy servers hosted at Google to optimize website content. This feature has been shown to <strong>reduce the size of web pages by 60%.</strong> To enable it, visit <b>Settings &gt; Data Saver</b> and toggle the option.
 </p>
 
 <p>


### PR DESCRIPTION
Data Saver is no longer available for iOS. Data reduction is 60%, not 50%.