### PR TITLE
Close partials.standard_multidevice_article tag

### DIFF
--- a/ios/links.html
+++ b/ios/links.html
@@ -104,3 +104,5 @@ If the user agrees, the app can open the App Store download page using the follo
 
 </div><div class="collapsible">
 
+{{/partials.standard_multidevice_article}}
+


### PR DESCRIPTION
Page was not rendering at https://developer.chrome.com/multidevice/ios/links.html.  This should fix it.