### PR TITLE
Update Android intents documentation about redirects

### DIFF
--- a/android/intents.html
+++ b/android/intents.html
@@ -82,11 +82,7 @@
   		<li><a href="http://developer.android.com/guide/components/activities.html">Android Activities</a></li>
   	</ul>
   	
-  	<p>And Chrome doesn’t launch an external app for a given Intent URI in the following cases.</p>
-	<ul>
-		<li>When the Intent URI is redirected from a typed in URL.</li>
-		<li>When the Intent URI is initiated without user gesture.</li>
-	</ul>
+  	<p>And Chrome doesn’t launch an external app for a given Intent URI when the Intent URI is initiated without user gesture.</p>
 
 
 </div>


### PR DESCRIPTION
Per https://bugs.chromium.org/p/chromium/issues/detail?id=814721, it
has been the case for a long time that redirects from a typed-in URL
*will* in fact launch intents. We don't currently have plans to change
this, so this commit updates the documentation accordingly.